### PR TITLE
added reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ $ ionic start myproject
   * Ionic CDN: [Nightly Build](http://code.ionicframework.com/#nightly)
   * Using bower: `bower install driftyco/ionic-bower#master`
   * For [Meteor](https://www.meteor.com/) applications: `meteor add urigo:ionic` 
+     - For a beginner level repo integrating Ionic&Angular with Meteor very quickly: https://github.com/ambujpunn/meteorionic
+     - For an advanced level repo integrating Ionic&Angular with Meteor: https://github.com/netanelgilad/meteor-ionic-example
+
 
 Once you have a release, use `js/ionic.js`, `js/ionic-angular.js`, and `css/ionic.css`.
 


### PR DESCRIPTION
Adding extra documentation to include my repo which is a simple integration between Ionic&Angular with Meteor (https://github.com/ambujpunn/meteorionic). This repo goes through the specific tasks to accomplish this. It is a very-easy to understand repo with very minimal amount of code in it. It would be very useful for a beginner as it shows the steps I had to take in order to integrate these technologies together when I was going through the beginner level phases.

I've also included https://github.com/netanelgilad/meteor-ionic-example's repo as it is more for an advanced user but still very helpful.